### PR TITLE
added option for appending more options to goober's output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Multiprocess and TestId don't work well together. So, how do we know which tests
 
 This plugin prints out 'nosetests -v' plus the paths to those failing tests. The idea is to make it as easy as possible to just run the troublesome tests from a multiprocess test run.
 
-To Enable:
+**To Enable:**
 - clone the goober repository 
 - cd into the goober repository and run ```pip install -e .```
 
-Usage:
+**Usage:**
 
 ```nosetests --goober --processes=-1 path/to/tests```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Multiprocess and TestId don't work well together. So, how do we know which tests
 
 This plugin prints out 'nosetests -v' plus the paths to those failing tests. The idea is to make it as easy as possible to just run the troublesome tests from a multiprocess test run.
 
+To Enable:
+- clone the goober repository 
+- cd into the goober repository and run ```pip install -e .```
+
 Usage:
 
 ```nosetests --goober --processes=-1 path/to/tests```

--- a/goober.py
+++ b/goober.py
@@ -39,6 +39,7 @@ class Goober(Plugin):
     def configure(self, options, conf):
         super(Goober, self).configure(options, conf)
         self.prefix = ''
+        self.extra_options = ''
         if not options.prefix:
             return
         self.env_vars = options.prefix.split(',')

--- a/goober.py
+++ b/goober.py
@@ -40,8 +40,10 @@ class Goober(Plugin):
 
     def configure(self, options, conf):
         super(Goober, self).configure(options, conf)
-        self.extra_options = options.extra.replace(',', ' ')
         self.prefix = ''
+        self.extra_options = ''
+        if options.extra:
+            self.extra_options = (options.extra).replace(',', ' ')
 
         if not options.prefix:
             return

--- a/goober.py
+++ b/goober.py
@@ -30,6 +30,10 @@ class Goober(Plugin):
                           type='string',
                           dest='prefix',
                           help="Environment variables to prepend to goober's output. For example, --goober-prefix='LOCALE' will attach 'LOCALE=<os.environ.get('LOCALE')> to 'nosetests -v --goober'")
+        parser.add_option('--goober-extra',
+                          action='store',
+                          help="append additional nose options to goober's output (give comma separated). For example: --goober-extra=--with-xunit,--with-xcover,--xcoverage-file=coverage.xml")
+
         super(Goober, self).options(parser, env)
 
     def configure(self, options, conf):
@@ -40,6 +44,8 @@ class Goober(Plugin):
         self.env_vars = options.prefix.split(',')
         if self.env_vars:
             self.assemble_prefix()
+        if options.goober_extra:
+            self.extra_options = str(options.goober_extra).replace(","," ")
 
     def assemble_prefix(self):
         self.prefix += ' '.join(["%s=%s" % (var, os.environ.get(var)) for var in self.env_vars if os.environ.get(var) is not None]) + ' '
@@ -91,5 +97,8 @@ class Goober(Plugin):
         msg = "nosetests -v --goober "
         if self.prefix:
             msg = self.prefix + msg + '--goober-prefix=' + ','.join(self.env_vars) + ' '
+        if self.extra_options:
+            msg += str(self.extra_options) + ' '
+        
         print msg + ' '.join(problems)
         

--- a/goober.py
+++ b/goober.py
@@ -32,21 +32,23 @@ class Goober(Plugin):
                           help="Environment variables to prepend to goober's output. For example, --goober-prefix='LOCALE' will attach 'LOCALE=<os.environ.get('LOCALE')> to 'nosetests -v --goober'")
         parser.add_option('--goober-extra',
                           action='store',
+                          type='string',
+                          dest= 'extra',
                           help="append additional nose options to goober's output (give comma separated). For example: --goober-extra=--with-xunit,--with-xcover,--xcoverage-file=coverage.xml")
 
         super(Goober, self).options(parser, env)
 
     def configure(self, options, conf):
         super(Goober, self).configure(options, conf)
+        self.extra_options = str(options.extra).replace(',', ' ')
         self.prefix = ''
-        self.extra_options = ''
+
         if not options.prefix:
             return
         self.env_vars = options.prefix.split(',')
         if self.env_vars:
             self.assemble_prefix()
-        if options.goober_extra:
-            self.extra_options = str(options.goober_extra).replace(","," ")
+
 
     def assemble_prefix(self):
         self.prefix += ' '.join(["%s=%s" % (var, os.environ.get(var)) for var in self.env_vars if os.environ.get(var) is not None]) + ' '
@@ -98,6 +100,7 @@ class Goober(Plugin):
         msg = "nosetests -v --goober "
         if self.prefix:
             msg = self.prefix + msg + '--goober-prefix=' + ','.join(self.env_vars) + ' '
+
         if self.extra_options:
             msg += str(self.extra_options) + ' '
         

--- a/goober.py
+++ b/goober.py
@@ -40,7 +40,7 @@ class Goober(Plugin):
 
     def configure(self, options, conf):
         super(Goober, self).configure(options, conf)
-        self.extra_options = str(options.extra).replace(',', ' ')
+        self.extra_options = options.extra.replace(',', ' ')
         self.prefix = ''
 
         if not options.prefix:
@@ -48,7 +48,6 @@ class Goober(Plugin):
         self.env_vars = options.prefix.split(',')
         if self.env_vars:
             self.assemble_prefix()
-
 
     def assemble_prefix(self):
         self.prefix += ' '.join(["%s=%s" % (var, os.environ.get(var)) for var in self.env_vars if os.environ.get(var) is not None]) + ' '

--- a/goober.py
+++ b/goober.py
@@ -101,7 +101,6 @@ class Goober(Plugin):
         msg = "nosetests -v --goober "
         if self.prefix:
             msg = self.prefix + msg + '--goober-prefix=' + ','.join(self.env_vars) + ' '
-
         if self.extra_options:
             msg += str(self.extra_options) + ' '
         


### PR DESCRIPTION
**Requirement:**
want to re-run failed tests with more options like --with-xunit because using nosetetsts.xml file to generate beautiful Test Report

**To Note** since its comma separated rule so the options whose value includes comma will not work EX. --cover-package=a,b,c 
but I don't see any better intuitive separator here & there are rare chances in re-run failed cases when one would require such option so something can live it at the moment
Please suggest if has to be changed then '&' looks a possible candidate
